### PR TITLE
Mesh tally amalgamation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,12 @@
 [submodule "contrib/openmc"]
 	path = contrib/openmc
-	url = https://github.com/magnoxemo/openmc.git
-	branch= external_sources_alias_sampler
+	url = https://github.com/openmc-dev/openmc.git
 [submodule "contrib/nekRS"]
 	path = contrib/nekRS
 	url = https://github.com/neams-th-coe/nekRS.git
 [submodule "contrib/moose"]
 	path = contrib/moose
-	url = git@github.com:magnoxemo/moose.git
-	branch= element_amalgamation
+	url = https://github.com/idaholab/moose.git
 [submodule "contrib/SAM"]
 	path = contrib/SAM
 	url = git@gitlab-nse.egs.anl.gov:SAM/SAM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,14 @@
 [submodule "contrib/openmc"]
 	path = contrib/openmc
-	url = https://github.com/openmc-dev/openmc.git
+	url = https://github.com/magnoxemo/openmc.git
+	branch= external_sources_alias_sampler
 [submodule "contrib/nekRS"]
 	path = contrib/nekRS
 	url = https://github.com/neams-th-coe/nekRS.git
 [submodule "contrib/moose"]
 	path = contrib/moose
-	url = https://github.com/idaholab/moose.git
+	url = git@github.com:magnoxemo/moose.git
+	branch= element_amalgamation
 [submodule "contrib/SAM"]
 	path = contrib/SAM
 	url = git@gitlab-nse.egs.anl.gov:SAM/SAM.git

--- a/include/markers/AmalgamationMarker.h
+++ b/include/markers/AmalgamationMarker.h
@@ -21,20 +21,20 @@
 #include "QuadraturePointMarker.h"
 
 /**
- * A marker which takes a given variable and checks if it is within a certain range of the extrme value.
+ * A marker which takes a given variable and checks if it is within a certain range of the extrme
+ * value.
  */
 class AmalgamationMarker : public QuadraturePointMarker
 {
 public:
   static InputParameters validParams();
 
-  AmalgamationMarker (const InputParameters & parameters);
+  AmalgamationMarker(const InputParameters & parameters);
 
 protected:
-   virtual Marker::MarkerValue computeQpMarker() override;
+  virtual Marker::MarkerValue computeQpMarker() override;
 
   /* user defined tolerance to compare the deviation of the _u[_qp] from the local average value */
   const Real _tolerance;
-  const Real TOLERENCE=1E-20; // to check if local_avg isn't zero.
-
+  const Real TOLERENCE = 1E-20; // to check if local_avg isn't zero.
 };

--- a/include/markers/AmalgamationMarker.h
+++ b/include/markers/AmalgamationMarker.h
@@ -31,7 +31,7 @@ public:
   AmalgamationMarker (const InputParameters & parameters);
 
 protected:
-  virtual MarkerValue computeQpMarker() override;
+   virtual Marker::MarkerValue computeQpMarker() override;
 
   /* user defined tolerance to compare the deviation of the 
     _u[_qp] from the local average value 

--- a/include/markers/AmalgamationMarker.h
+++ b/include/markers/AmalgamationMarker.h
@@ -33,9 +33,8 @@ public:
 protected:
    virtual Marker::MarkerValue computeQpMarker() override;
 
-  /* user defined tolerance to compare the deviation of the 
-    _u[_qp] from the local average value 
-     */
+  /* user defined tolerance to compare the deviation of the _u[_qp] from the local average value */
   const Real _tolerance;
+  const Real TOLERENCE=1E-20; // to check if local_avg isn't zero.
 
 };

--- a/include/markers/AmalgamationMarker.h
+++ b/include/markers/AmalgamationMarker.h
@@ -1,0 +1,41 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#pragma once
+
+#include "QuadraturePointMarker.h"
+
+/**
+ * A marker which takes a given variable and checks if it is within a certain range of the extrme value.
+ */
+class AmalgamationMarker : public QuadraturePointMarker
+{
+public:
+  static InputParameters validParams();
+
+  AmalgamationMarker (const InputParameters & parameters);
+
+protected:
+  virtual MarkerValue computeQpMarker() override;
+
+  /* user defined tolerance to compare the deviation of the 
+    _u[_qp] from the local average value 
+     */
+  const Real _tolerance;
+
+};

--- a/include/tallies/MeshTally.h
+++ b/include/tallies/MeshTally.h
@@ -17,7 +17,7 @@
 /********************************************************************/
 
 #pragma once
-#include<unordered_map>
+#include <unordered_map>
 #include "Marker.h"
 #include "TallyBase.h"
 #include "OpenMCCellAverageProblem.h"
@@ -114,5 +114,6 @@ protected:
   std::unique_ptr<libMesh::ReplicatedMesh> _libmesh_mesh_copy;
   /// A mapping between the elements in '_libmesh_mesh_copy' and the elements in the MooseMesh.
   std::vector<unsigned int> _active_to_total_mapping;
-  std::unordered_map<unsigned int, unsigned int>_total_to_active_mapping; //hash map for inverse mapping
+  std::unordered_map<unsigned int, unsigned int>
+      _total_to_active_mapping; // hash map for inverse mapping
 };

--- a/include/tallies/MeshTally.h
+++ b/include/tallies/MeshTally.h
@@ -18,7 +18,7 @@
 
 #pragma once
 #include<unordered_map>
-
+#include "Marker.h"
 #include "TallyBase.h"
 #include "OpenMCCellAverageProblem.h"
 
@@ -114,5 +114,5 @@ protected:
   std::unique_ptr<libMesh::ReplicatedMesh> _libmesh_mesh_copy;
   /// A mapping between the elements in '_libmesh_mesh_copy' and the elements in the MooseMesh.
   std::vector<unsigned int> _active_to_total_mapping;
-  std::unordered_map<unsigned int, unsigned int>_total_to_active_mapping;
+  std::unordered_map<unsigned int, unsigned int>_total_to_active_mapping; //hash map for inverse mapping
 };

--- a/include/tallies/MeshTally.h
+++ b/include/tallies/MeshTally.h
@@ -17,6 +17,7 @@
 /********************************************************************/
 
 #pragma once
+#include<unordered_map>
 
 #include "TallyBase.h"
 #include "OpenMCCellAverageProblem.h"
@@ -113,4 +114,5 @@ protected:
   std::unique_ptr<libMesh::ReplicatedMesh> _libmesh_mesh_copy;
   /// A mapping between the elements in '_libmesh_mesh_copy' and the elements in the MooseMesh.
   std::vector<unsigned int> _active_to_total_mapping;
+  std::unordered_map<unsigned int, unsigned int>_total_to_active_maping;
 };

--- a/include/tallies/MeshTally.h
+++ b/include/tallies/MeshTally.h
@@ -23,7 +23,6 @@
 
 #include "openmc/tallies/filter_mesh.h"
 
-#include "libmesh/mesh.h"
 namespace libMesh
 {
 class ReplicatedMesh;

--- a/include/tallies/MeshTally.h
+++ b/include/tallies/MeshTally.h
@@ -23,6 +23,7 @@
 
 #include "openmc/tallies/filter_mesh.h"
 
+#include "libmesh/mesh.h"
 namespace libMesh
 {
 class ReplicatedMesh;

--- a/include/tallies/MeshTally.h
+++ b/include/tallies/MeshTally.h
@@ -114,5 +114,5 @@ protected:
   std::unique_ptr<libMesh::ReplicatedMesh> _libmesh_mesh_copy;
   /// A mapping between the elements in '_libmesh_mesh_copy' and the elements in the MooseMesh.
   std::vector<unsigned int> _active_to_total_mapping;
-  std::unordered_map<unsigned int, unsigned int>_total_to_active_maping;
+  std::unordered_map<unsigned int, unsigned int>_total_to_active_mapping;
 };

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -30,15 +30,16 @@ AmalgamationMarker ::validParams()
     "tolerance",
     "user defined tolerance to compare the deviation of the "
     "_u[_qp] from the local average value"
-    "if (abs((_local_avg-_u[_qp])/_local_avg)<tolerance) then AMALGAMATE"
+    "if (abs((_local_avg-_u[_qp])/_local_avg)<tolerance) then AMALGAMATE");
     //To do
     /*introduce _element_age concept*/
 
-AmalgamationMarker ::AmalgamationMarker (const InputParameters & parameters)
-  : QuadraturePointMarker(parameters),
-    _tolerance(getParam<Real>("tolerance"))
+AmalgamationMarker::AmalgamationMarker(const InputParameters& parameters)
+  : QuadraturePointMarker(parameters)
 {
+  _tolerance = getParam<Real>("tolerance");
 }
+
 
 Marker::MarkerValue
 AmalgamationMarker::computeQpMarker()
@@ -61,5 +62,7 @@ AmalgamationMarker::computeQpMarker()
   // Avoid a divide by zero in the comparison metric and just return a do nothing state.
   if ((std::abs((_local_avg-_u[_qp])/_local_avg)<_tolerance)
     return MarkerValue::AMALGAMATE;
+  else
+    return MarkerValue::DO_NOTHING;
 
 }

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -40,13 +40,12 @@ AmalgamationMarker::AmalgamationMarker(const InputParameters& parameters)
 {
 }
 
-
 Marker::MarkerValue
 AmalgamationMarker::computeQpMarker()
 { 
   /* calculate local average value.
   Loop over the local elements and store the solution in a Real var*/
-  Real local_avg;
+  Real local_avg=0;
   Real sum=0;
   for (unsigned int qp=0;qp<_qrule->n_points();qp++)
     {
@@ -60,8 +59,9 @@ AmalgamationMarker::computeQpMarker()
     return MarkerValue::DO_NOTHING;
   }
   // Avoid a divide by zero in the comparison metric and just return a do nothing state.
-  if ((std::abs((_local_avg-_u[_qp])/_local_avg)<_tolerance)
+  if ((std::abs((local_avg-_u[_qp])/local_avg)<_tolerance))
     return MarkerValue::AMALGAMATE;
+    //showing error in the test. error: 'AMALGAMATE' is not a member of 'Marker::MarkerValue'
   else
     return MarkerValue::DO_NOTHING;
 

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -25,17 +25,17 @@ AmalgamationMarker ::validParams()
 {
   auto params = QuadraturePointMarker::validParams();
   params.addClassDescription(
-    "Mesh tally amalgamation marker based on deviation from the local mean value");
+      "Mesh tally amalgamation marker based on deviation from the local mean value");
   params.addRequiredParam<Real>(
-    "tolerance",
-    "user defined tolerance to compare the deviation of the "
-    "_u[_qp] from the local average value"
-    "if (abs((_local_avg-_u[_qp])/_local_avg)<tolerance) then AMALGAMATE");
-    //To do
-    /*introduce _element_age concept*/
+      "tolerance",
+      "user defined tolerance to compare the deviation of the "
+      "_u[_qp] from the local average value"
+      "if (abs((_local_avg-_u[_qp])/_local_avg)<tolerance) then AMALGAMATE");
+  // To do
+  /*introduce _element_age concept*/
   return params;
 }
-AmalgamationMarker::AmalgamationMarker(const InputParameters& parameters)
+AmalgamationMarker::AmalgamationMarker(const InputParameters & parameters)
   : QuadraturePointMarker(parameters), _tolerance(parameters.get<Real>("tolerance"))
 {
 }
@@ -45,24 +45,23 @@ AmalgamationMarker::computeQpMarker()
 {
   /* calculate local average value.
   Loop over the local elements and store the solution in a Real var*/
-  Real local_avg=0;
-  Real sum=0;
-  for (unsigned int qp=0;qp<_qrule->n_points();qp++)
-    {
-        sum+=_u[qp];
-    }
+  Real local_avg = 0;
+  Real sum = 0;
+  for (unsigned int qp = 0; qp < _qrule->n_points(); qp++)
+  {
+    sum += _u[qp];
+  }
   // qurle->n_points() should never be zero. But do I need to use if statement to check?
-  local_avg=sum/_qrule->n_points();
-  //local_avg it could be zero. So ig it needs to be checked
-  if (std::abs(local_avg)<TOLERANCE)
+  local_avg = sum / _qrule->n_points();
+  // local_avg it could be zero. So ig it needs to be checked
+  if (std::abs(local_avg) < TOLERANCE)
   {
     return MarkerValue::DO_NOTHING;
   }
   // Avoid a divide by zero in the comparison metric and just return a do nothing state.
-  if ((std::abs((local_avg-_u[_qp])/local_avg)<_tolerance))
+  if ((std::abs((local_avg - _u[_qp]) / local_avg) < _tolerance))
     return MarkerValue::AMALGAMATE;
-    //solution-> add the AMALGAMATE enum in moose src
+  // solution-> add the AMALGAMATE enum in moose src
   else
     return MarkerValue::DO_NOTHING;
-
 }

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -42,18 +42,18 @@ AmalgamationMarker::AmalgamationMarker(const InputParameters& parameters)
 
 Marker::MarkerValue
 AmalgamationMarker::computeQpMarker()
-{ 
+{
   /* calculate local average value.
   Loop over the local elements and store the solution in a Real var*/
   Real local_avg=0;
   Real sum=0;
   for (unsigned int qp=0;qp<_qrule->n_points();qp++)
     {
-        sum+=_u_neighbor[qp];
+        sum+=_u[qp];
     }
-  // qurle->n_points() should never be zero. But do I need to use if statement to check? 
+  // qurle->n_points() should never be zero. But do I need to use if statement to check?
   local_avg=sum/_qrule->n_points();
-  //local_avg it could be zero. So ig it needs to be checked 
+  //local_avg it could be zero. So ig it needs to be checked
   if (std::abs(local_avg)<TOLERANCE)
   {
     return MarkerValue::DO_NOTHING;

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -49,19 +49,19 @@ AmalgamationMarker::computeQpMarker()
   Real sum=0;
   for (unsigned int qp=0;qp<_qrule->n_points();qp++)
     {
-        sum=sum+_u[qp];
+        sum+=_u_neighbor[qp];
     }
   // qurle->n_points() should never be zero. But do I need to use if statement to check? 
   local_avg=sum/_qrule->n_points();
   //local_avg it could be zero. So ig it needs to be checked 
-  if (local_avg==0)
+  if (std::abs(local_avg)<TOLERANCE)
   {
     return MarkerValue::DO_NOTHING;
   }
   // Avoid a divide by zero in the comparison metric and just return a do nothing state.
   if ((std::abs((local_avg-_u[_qp])/local_avg)<_tolerance))
     return MarkerValue::AMALGAMATE;
-    //showing error in the test. error: 'AMALGAMATE' is not a member of 'Marker::MarkerValue'
+    //solution-> add the AMALGAMATE enum in moose src
   else
     return MarkerValue::DO_NOTHING;
 

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -1,0 +1,65 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
+#include "AmalgamationMarker.h"
+
+registerMooseObject("MooseApp", AmalgamationMarker);
+
+InputParameters
+AmalgamationMarker ::validParams()
+{
+  auto params = QuadraturePointMarker::validParams();
+  params.addClassDescription(
+    "Mesh tally amalgamation marker based on deviation from the local mean value");
+  params.addRequiredParam<Real>(
+    "tolerance",
+    "user defined tolerance to compare the deviation of the "
+    "_u[_qp] from the local average value"
+    "if (abs((_local_avg-_u[_qp])/_local_avg)<tolerance) then AMALGAMATE"
+    //To do
+    /*introduce _element_age concept*/
+
+AmalgamationMarker ::AmalgamationMarker (const InputParameters & parameters)
+  : QuadraturePointMarker(parameters),
+    _tolerance(getParam<Real>("tolerance"))
+{
+}
+
+Marker::MarkerValue
+AmalgamationMarker::computeQpMarker()
+{ 
+  /* calculate local average value.
+  Loop over the local elements and store the solution in a Real var*/
+  Real local_avg;
+  Real sum=0;
+  for (qp=0;qp<_qrule->n_points();qp++;)
+    {
+        sum=sum+_u_neighbor[qp];
+    }
+  // qurle->n_points() should never be zero. But do I need to use if statement to check? 
+  local_avg=sum/_qrule->n_points();
+  //local_avg it could be zero. So ig it needs to be checked 
+  if (local_avg==0)
+  {
+    return MarkerValue::DO_NOTHING;
+  }
+  // Avoid a divide by zero in the comparison metric and just return a do nothing state.
+  if ((std::abs((_local_avg-_u[_qp])/_local_avg)<_tolerance)
+    return MarkerValue::AMALGAMATE;
+
+}

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -47,7 +47,7 @@ AmalgamationMarker::computeQpMarker()
   Loop over the local elements and store the solution in a Real var*/
   Real local_avg;
   Real sum=0;
-  for (qp=0;qp<_qrule->n_points();qp++;)
+  for (unsigned int qp=0;qp<_qrule->n_points();qp++)
     {
         sum=sum+_u_neighbor[qp];
     }

--- a/src/markers/AmalgamationMarker.C
+++ b/src/markers/AmalgamationMarker.C
@@ -33,11 +33,11 @@ AmalgamationMarker ::validParams()
     "if (abs((_local_avg-_u[_qp])/_local_avg)<tolerance) then AMALGAMATE");
     //To do
     /*introduce _element_age concept*/
-
+  return params;
+}
 AmalgamationMarker::AmalgamationMarker(const InputParameters& parameters)
-  : QuadraturePointMarker(parameters)
+  : QuadraturePointMarker(parameters), _tolerance(parameters.get<Real>("tolerance"))
 {
-  _tolerance = getParam<Real>("tolerance");
 }
 
 
@@ -50,7 +50,7 @@ AmalgamationMarker::computeQpMarker()
   Real sum=0;
   for (unsigned int qp=0;qp<_qrule->n_points();qp++)
     {
-        sum=sum+_u_neighbor[qp];
+        sum=sum+_u[qp];
     }
   // qurle->n_points() should never be zero. But do I need to use if statement to check? 
   local_avg=sum/_qrule->n_points();

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -228,12 +228,13 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
       auto elem_id = _use_dof_map ? _active_to_total_mapping[e] : mesh_offset + e;
 
       //check if the element if flagged for amalgamation
-      libMesh::Elem* elem_ptr = _mesh_filter->get_elem(elem_id);
+      auto elem_ptr = _mesh.queryElemPtr(elem_id)
+      //error: 'class openmc::MeshFilter' has no member named 'get_elem'
       //openmc::mesh_filter doesn't have anything like get_elem
       //
       if (elem_ptr != nullptr)
       {
-          if (elem_ptr->refinement_flag()==Marker::AMALGAMATE)
+          if (elem_ptr->refinement_flag()==MarkerValue::AMALGAMATE)
           {
               Real total_tally_of_the_cluster=tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + e);
               Real total_volume_of_the_cluster= elem_ptr->volume();
@@ -244,7 +245,7 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
                 //avoid amalgamation if a single element is marked for amalgamation
                 if (neighbor_ptr != nullptr)
                 {
-                    if (neighbor_ptr->refinement_flag()==Marker::AMALGAMATE)
+                    if (neighbor_ptr->refinement_flag()==MarkerValue::AMALGAMATE)
                     {
                         //error Elem::AMALGAMATION not found in libmesh
                         // so I think the enum should be added to the libmesh?

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -232,7 +232,7 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
       auto elem_id = _use_dof_map ? _active_to_total_mapping[e] : mesh_offset + e;
 
       //check if the element if flagged for amalgamation
-      auto elem_ptr = _mesh.queryElemPtr(elem_id)
+      auto elem_ptr = _mesh.queryElemPtr(elem_id); 
       //error: 'class openmc::MeshFilter' has no member named 'get_elem'
       //openmc::mesh_filter doesn't have anything like get_elem
       //

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -243,19 +243,16 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
               {
                 const libMesh::Elem* neighbor_ptr = elem_ptr->n_neighbors(side_id); //maybe wrong
                 //avoid amalgamation if a single element is marked for amalgamation
-                if (neighbor_ptr != nullptr)
+                if (neighbor_ptr != nullptr && neighbor_ptr->refinement_flag()==MarkerValue::AMALGAMATE)
                 {
-                    if (neighbor_ptr->refinement_flag()==MarkerValue::AMALGAMATE)
-                    {
-                        //error Elem::AMALGAMATION not found in libmesh
-                        // so I think the enum should be added to the libmesh?
-                        total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + side_id + e);  //need some clarification on that
-                        /*not sure how that thing would work but _mesh_filter must have
-                         an upper bound for the bin index. Doing side_id+e isn't the solution.
-                         maybe (e+/-side_id)/2 . at the start of the vector + end of the vector -
-                         in the middle +/-*/
-                        total_volume_of_the_cluster +=neighbor_ptr->volume();
-                    }
+                    //TODO
+					//I have to do an inverse map which goes from element DoF IDs to tally bin IDs
+                    //(a _total_to_active_mapping
+					auto neighbor_bin = _total_to_active[neighbor_ptr->id()];
+					total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + neighbor_bin);
+
+                    total_volume_of_the_cluster +=neighbor_ptr->volume();
+
                 }
            }
 

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -231,7 +231,7 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
       libMesh::Elem* elem_ptr = _mesh_filter->get_elem(elem_id);
       if (elem_ptr != nullptr)
       {
-          if (elem_ptr->refinement_flag==Elem::AMALGAMATE)
+          if (elem_ptr->refinement_flag()==Elem::AMALGAMATE)
           {
               Real total_tally_of_the_cluster=tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + e);
               Real total_vol_of_the_cluster= elem_ptr->volume();

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -242,7 +242,7 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
                 //avoid amalgamation if a single element is marked for amalgamation
                 if (neighbor_ptr != nullptr)
                 {
-                    if (neighbor_ptr->refinement_flag==Elem::AMALGAMATE)
+                    if (neighbor_ptr->refinement_flag()==Elem::AMALGAMATE)
                     {
                         total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + side_id*e);  //need some clarification on that
                         total_volume_of_the_cluster +=neighbor_ptr->volume();

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -147,6 +147,7 @@ MeshTally::spatialFilter()
     if (_use_dof_map)
     {
       _active_to_total_mapping.clear();
+      _total_to_active_mapping.clear(); //clearing the hash map
 
       auto begin = _tally_blocks.size() > 0
                        ? msh->active_subdomain_set_elements_begin(_tally_blocks)
@@ -154,7 +155,10 @@ MeshTally::spatialFilter()
       auto end = _tally_blocks.size() > 0 ? msh->active_subdomain_set_elements_end(_tally_blocks)
                                           : msh->active_elements_end();
       for (const auto & old_elem : libMesh::as_range(begin, end))
+      {
         _active_to_total_mapping.push_back(old_elem->id());
+        _total_to_active_mapping.insert(std::make_pair(old_elem->id(),_active_to_total_mapping.size()-1)); //hash map of the active_to_total
+      }
 
       _active_to_total_mapping.shrink_to_fit();
     }
@@ -248,7 +252,7 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
                     //TODO
 					//I have to do an inverse map which goes from element DoF IDs to tally bin IDs
                     //(a _total_to_active_mapping
-					auto neighbor_bin = _total_to_active[neighbor_ptr->id()];
+					auto neighbor_bin = _total_to_active_mapping[neighbor_ptr->id()];
 					total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + neighbor_bin);
 
                     total_volume_of_the_cluster +=neighbor_ptr->volume();

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -234,7 +234,7 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
           if (elem_ptr->refinement_flag()==Elem::AMALGAMATE)
           {
               Real total_tally_of_the_cluster=tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + e);
-              Real total_vol_of_the_cluster= elem_ptr->volume();
+              Real total_volume_of_the_cluster= elem_ptr->volume();
               const unsigned int n_sides = elem_ptr->n_sides();
               for (unsigned int side_id = 0; side_id < n_sides; ++side_id)
               {
@@ -251,10 +251,6 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
               }
 
               Real power_fraction =elem_ptr->volume()*total_tally_of_the_cluster/total_volume_of_the_cluster;
-              // divide each tally by the volume that it corresponds to in MOOSE
-              // because we will apply it as a volumetric tally (per unit volume).
-              // Because we require that the mesh template has units of cm based on the
-              // mesh constructors in OpenMC, we need to adjust the division
               Real volumetric_power = power_fraction;
               volumetric_power *= norm_by_src_rate
                                       ? _openmc_problem.tallyMultiplier(global_score) /

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -17,8 +17,8 @@
 /********************************************************************/
 
 #ifdef ENABLE_OPENMC_COUPLING
-#include "MeshTally.h"
 
+#include "MeshTally.h"
 #include "libmesh/replicated_mesh.h"
 
 registerMooseObject("CardinalApp", MeshTally);
@@ -232,28 +232,28 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
       auto elem_id = _use_dof_map ? _active_to_total_mapping[e] : mesh_offset + e;
 
       //check if the element if flagged for amalgamation
-      auto elem_ptr = _mesh.queryElemPtr(elem_id); 
+      auto elem_ptr = _mesh.queryElemPtr(elem_id);
       //error: 'class openmc::MeshFilter' has no member named 'get_elem'
       //openmc::mesh_filter doesn't have anything like get_elem
       //
       if (elem_ptr != nullptr)
       {
-          if (elem_ptr->refinement_flag()==MarkerValue::AMALGAMATE)
+          if (elem_ptr->refinement_flag()== Marker::MarkerValue::DO_NOTHING)
           {
               Real total_tally_of_the_cluster=tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + e);
               Real total_volume_of_the_cluster= elem_ptr->volume();
               const unsigned int n_sides = elem_ptr->n_sides();
               for (unsigned int side_id = 0; side_id < n_sides; ++side_id)
               {
-                const libMesh::Elem* neighbor_ptr = elem_ptr->n_neighbors(side_id); //maybe wrong
+                auto neighbor_ptr = elem_ptr->neighbor_ptr(side_id); //maybe wrong
                 //avoid amalgamation if a single element is marked for amalgamation
-                if (neighbor_ptr != nullptr && neighbor_ptr->refinement_flag()==MarkerValue::AMALGAMATE)
+                if (neighbor_ptr != nullptr && neighbor_ptr->refinement_flag()== Marker::MarkerValue::DO_NOTHING)
                 {
                     //TODO
 					//I have to do an inverse map which goes from element DoF IDs to tally bin IDs
                     //(a _total_to_active_mapping
-					auto neighbor_bin = _total_to_active_mapping[neighbor_ptr->id()];
-					total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + neighbor_bin);
+		    		auto neighbor_bin = _total_to_active_mapping[neighbor_ptr->id()];
+		    		total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + neighbor_bin);
 
                     total_volume_of_the_cluster +=neighbor_ptr->volume();
 

--- a/src/tallies/MeshTally.C
+++ b/src/tallies/MeshTally.C
@@ -238,17 +238,17 @@ MeshTally::storeResultsInner(const std::vector<unsigned int> & var_numbers,
               const unsigned int n_sides = elem_ptr->n_sides();
               for (unsigned int side_id = 0; side_id < n_sides; ++side_id)
               {
-                const libMesh::Elem* neighbor_ptr = elem_ptr->neighbor(side_id);
+                const libMesh::Elem* neighbor_ptr = elem_ptr->neighbor(side_id); //maybe wrong
                 //avoid amalgamation if a single element is marked for amalgamation
                 if (neighbor_ptr != nullptr)
                 {
                     if (neighbor_ptr->refinement_flag()==Elem::AMALGAMATE)
                     {
-                        total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + side_id*e);  //need some clarification on that
+                        total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + side_id + e);  //need some clarification on that
                         total_volume_of_the_cluster +=neighbor_ptr->volume();
                     }
                 }
-              }
+           }
 
               Real power_fraction =elem_ptr->volume()*total_tally_of_the_cluster/total_volume_of_the_cluster;
               Real volumetric_power = power_fraction;


### PR DESCRIPTION
**Element Amalgamation - Post-Processing**  

This PR is for doing the element amalgamation in the post-processing. Once OpenMC is done with its simulation, Cardinal will read the mesh data. We can get the `element_id` and use it to get the current MOOSE element:  
`libMesh::Elem* elem_ptr = _mesh_filter->get_elem(elem_id);`  

Then we can check if that element is marked for `AMALGAMATION`:  
`if (elem_ptr->refinement_flag() == Elem::AMALGAMATE)`.  

If the element is marked for `AMALGAMATION`, we have to find the cluster (for now, elements could be clustered only with the neighboring elements).  

- Tally score of the main element:  
  `Real total_tally_of_the_cluster = tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + e);`  
- Volume of the main element:  
  `Real total_volume_of_the_cluster = elem_ptr->volume();`  

We iterate through the neighbor elements (todo: need to check if the mapping is correct or not), and if they are also marked for `AMALGAMATION`, we increment `total_tally_of_the_cluster` and `total_volume_of_the_cluster`. Finally, the volumetric mean is calculated as:  
`Real power_fraction = elem_ptr->volume() * total_tally_of_the_cluster / total_volume_of_the_cluster;`.  

If the `if (elem_ptr->refinement_flag() != Elem::AMALGAMATE)`, then presume the normal operation.

confusion:
` total_tally_of_the_cluster += tally_vals[local_score](ext_bin * _mesh_filter->n_bins() + side_id*e);  //need some clarification on that` (not sure but ig `side_id `and  `e` they aren't of the same data type) 
@gonuke