### PR TITLE
adding error fraction user object

### DIFF
--- a/include/userobjects/ErrorFractionHeuristicUserObject.h
+++ b/include/userobjects/ErrorFractionHeuristicUserObject.h
@@ -2,23 +2,25 @@
 
 #include "ClusteringUserObject.h"
 
-class ErrorFractionHeuristicUserObject:public ClusteringUserObject{
+class ErrorFractionHeuristicUserObject : public ClusteringUserObject
+{
 
 public:
-    static InputParameters validParams();
-    ErrorFractionHeuristicUserObject(const InputParameters& params);
+  static InputParameters validParams();
+  ErrorFractionHeuristicUserObject(const InputParameters & params);
+
 protected:
-    virtual bool belongsToCluster(libMesh::Elem* base_element,libMesh::Elem*) override;
-    virtual void execute() override;
-    void extremesFinder();
+  virtual bool belongsToCluster(libMesh::Elem * base_element,
+                                libMesh::Elem * neighbor_elem) override;
+  virtual void execute() override;
+  void extremesFinder();
 
-    Real _max  =0; //maybe not a good presumption
-    Real _min  =0;
+  Real _max;
+  Real _min;
 
-    Real _upper_fraction;
-    Real _lower_fraction;
+  Real _upper_fraction;
+  Real _lower_fraction;
 
-    Real _upper_cut_off;
-    Real _lower_cut_off;
-
+  Real _upper_cut_off;
+  Real _lower_cut_off;
 };

--- a/include/userobjects/ErrorFractionHeuristicUserObject.h
+++ b/include/userobjects/ErrorFractionHeuristicUserObject.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ClusteringUserObject.h"
+
+class ErrorFractionHeuristicUserObject:public ClusteringUserObject{
+
+public:
+    static InputParameters validParams();
+    ErrorFractionHeuristicUserObject(const InputParameters& params);
+protected:
+    virtual bool belongsToCluster(libMesh::Elem* base_element,libMesh::Elem*) override;
+    virtual void execute() override;
+    void extremesFinder();
+
+    Real _max  =0; //maybe not a good presumption
+    Real _min  =0;
+
+    Real _upper_fraction;
+    Real _lower_fraction;
+
+    Real _upper_cut_off;
+    Real _lower_cut_off;
+
+};

--- a/src/userobjects/ErrorFractionHeuristicUserObject.C
+++ b/src/userobjects/ErrorFractionHeuristicUserObject.C
@@ -1,0 +1,62 @@
+#include "ErrorFractionHeuristicUserObject.h"
+
+registerMooseObject("CardinalApp",ErrorFractionHeuristicUserObject);
+
+InputParameters
+ErrorFractionHeuristicUserObject::validParams(){
+
+    InputParameters param = ClusteringUserObject::validParams();
+    param.addRequiredParam<Real>("upper_fraction","upper percentage of error for the heuristics");
+    param.addRequiredParam<Real>("lower_fraction","lower percentage of error for the heuristics");
+    param.addClassDescription(" mimics the error fraction marker in moose");
+
+    return param;
+}
+ErrorFractionHeuristicUserObject::ErrorFractionHeuristicUserObject(const InputParameters & params):
+                            ClusteringUserObject(params),
+        _upper_fraction(getParam<Real>("upper_fraction")),
+        _lower_fraction(getParam<Real>("lower_fraction"))
+{
+
+}
+
+void
+ErrorFractionHeuristicUserObject::extremesFinder(){
+
+    double score;
+    for (auto & elem : _mesh.active_element_ptr_range())
+    {
+        //should I add any nullptr check?
+        score = getMetricData(elem);
+        if (_max<score){
+            _max = score;
+        }
+        if (_min>score){
+            _min = score;
+        }
+    }
+    _upper_cut_off = (1 - _upper_fraction) *_max;
+    _lower_cut_off = _lower_fraction *(_max - _min) + _min;
+
+
+}
+
+void
+ErrorFractionHeuristicUserObject::execute(){
+    applyNoClusteringInitialCondition();
+    extremesFinder(); //should it be inside applyNoClusteringInitialCondition?
+    // that function iterates through the mesh as well
+    // but they don't serve the same purpose
+    findCluster();
+}
+
+bool
+ErrorFractionHeuristicUserObject::belongsToCluster(libMesh::Elem* base_element, libMesh::Elem* neighbor_elem){
+    if (getMetricData(base_element)>_upper_cut_off and getMetricData(neighbor_elem)>_upper_cut_off){
+        return true;
+    }
+    else if (getMetricData(base_element)<_lower_cut_off and getMetricData(neighbor_elem)<_lower_cut_off){
+        return true;
+    }
+    return false;
+}

--- a/src/userobjects/ErrorFractionHeuristicUserObject.C
+++ b/src/userobjects/ErrorFractionHeuristicUserObject.C
@@ -1,62 +1,67 @@
 #include "ErrorFractionHeuristicUserObject.h"
 
-registerMooseObject("CardinalApp",ErrorFractionHeuristicUserObject);
+registerMooseObject("CardinalApp", ErrorFractionHeuristicUserObject);
 
 InputParameters
-ErrorFractionHeuristicUserObject::validParams(){
-
-    InputParameters param = ClusteringUserObject::validParams();
-    param.addRequiredParam<Real>("upper_fraction","upper percentage of error for the heuristics");
-    param.addRequiredParam<Real>("lower_fraction","lower percentage of error for the heuristics");
-    param.addClassDescription(" mimics the error fraction marker in moose");
-
-    return param;
-}
-ErrorFractionHeuristicUserObject::ErrorFractionHeuristicUserObject(const InputParameters & params):
-                            ClusteringUserObject(params),
-        _upper_fraction(getParam<Real>("upper_fraction")),
-        _lower_fraction(getParam<Real>("lower_fraction"))
+ErrorFractionHeuristicUserObject::validParams()
 {
 
+  InputParameters param = ClusteringUserObject::validParams();
+  param.addRequiredParam<Real>("upper_fraction", "upper percentage of error for the heuristics");
+  param.addRequiredParam<Real>("lower_fraction", "lower percentage of error for the heuristics");
+  param.addClassDescription(" mimics the error fraction marker in moose");
+
+  return param;
+}
+ErrorFractionHeuristicUserObject::ErrorFractionHeuristicUserObject(const InputParameters & params)
+  : ClusteringUserObject(params),
+    _upper_fraction(getParam<Real>("upper_fraction")),
+    _lower_fraction(getParam<Real>("lower_fraction")),
+    _max (0),
+    _min(_std::numeric_limits<Real>::max())
+{
 }
 
 void
-ErrorFractionHeuristicUserObject::extremesFinder(){
+ErrorFractionHeuristicUserObject::extremesFinder()
+{
 
-    double score;
-    for (auto & elem : _mesh.active_element_ptr_range())
+  double score;
+  for (auto & elem : _mesh.active_element_ptr_range())
+  {
+    // should I add any nullptr check?
+    score = getMetricData(elem);
+    if (_max < score)
     {
-        //should I add any nullptr check?
-        score = getMetricData(elem);
-        if (_max<score){
-            _max = score;
-        }
-        if (_min>score){
-            _min = score;
-        }
+      _max = score;
     }
-    _upper_cut_off = (1 - _upper_fraction) *_max;
-    _lower_cut_off = _lower_fraction *(_max - _min) + _min;
-
-
+    if (_min > score)
+    {
+      _min = score;
+    }
+  }
+  _upper_cut_off = (1 - _upper_fraction) * _max;
+  _lower_cut_off = _lower_fraction * (_max - _min) + _min;
 }
 
 void
-ErrorFractionHeuristicUserObject::execute(){
-    applyNoClusteringInitialCondition();
-    extremesFinder(); //should it be inside applyNoClusteringInitialCondition?
-    // that function iterates through the mesh as well
-    // but they don't serve the same purpose
-    findCluster();
+ErrorFractionHeuristicUserObject::execute()
+{
+  applyNoClusteringInitialCondition();
+  extremesFinder();
+  // should it be inside applyNoClusteringInitialCondition?
+  //  that function iterates through the mesh as well
+  //  but they don't serve the same purpose
+  findCluster();
 }
 
 bool
-ErrorFractionHeuristicUserObject::belongsToCluster(libMesh::Elem* base_element, libMesh::Elem* neighbor_elem){
-    if (getMetricData(base_element)>_upper_cut_off and getMetricData(neighbor_elem)>_upper_cut_off){
-        return true;
-    }
-    else if (getMetricData(base_element)<_lower_cut_off and getMetricData(neighbor_elem)<_lower_cut_off){
-        return true;
-    }
-    return false;
+ErrorFractionHeuristicUserObject::belongsToCluster(libMesh::Elem * base_element,
+                                                   libMesh::Elem * neighbor_elem)
+{
+
+  double base_val = getMetricData(base_element);
+  double neighbor_val = getMetricData(neighbor_element);
+  return ((std::min(base_val, neighbor_val) > _upper_cut_off) ||
+          (std::max(base_val, neighbor_val) < _lower_cut_off));
 }


### PR DESCRIPTION
**PR Summary:**

This pull request introduces a `ErrorFractionHeuristicsUserObject` which should mimic the `ErrorFractionMarker`. 
It would cluster elements which would have values within a certain percentage of the maximum or minimum.
Parameters `upper_fraction` and `lower fraction` set the values of these percentage.

**Algorithm:**
 Global max and min is found by iteration through the mesh. After that the `upper_cut_off` and `lower_cut_off ` is calculated as

`_upper_cut_off = (1 - _upper_fraction) *_max;`
`_lower_cut_off = _lower_fraction *(_max - _min) + _min;`

based on the values of _upper_cut_off and _lower_cut_off the heuristic is performed. If both of the elements belong to a of in one cut_off region ( not one in upper and one in lower) it would return true.

**Uses**

- Can be used with any error indicator from moose or cardinal . 

closes #7 