### PR TITLE
adding clustering codes for review

### DIFF
--- a/doc/content/source/userobjects/ClusteringUserObject.md
+++ b/doc/content/source/userobjects/ClusteringUserObject.md
@@ -2,16 +2,17 @@
 
 ## Description
 
-ClusteringUserObject works as the base class for clustering in Cardinal for indentifying clusters, where it could be beneficial to apply
+`ClusteringUserObject` works as the base class in Cardinal for indentifying clusters in mesh results, where it may be beneficial to apply
 mesh-tally amalgamation both in post processing or on the fly. ClusteringUserObject inherits from 
 [GeneralUserObject](GeneralUserObject.md). It implements the mesh walking process. This base class assumes that only active
-elements, sharing at least one common side can be clustered together based on some heuristics. 
+elements, sharing at least one common side can be clustered together based on heuristics that will be implemented 
+in user objects derived from this class. 
 
 !listing /ClusteringUserObject.h start=doco-user-object-interface-begin end=doco-user-object-interface-end include-start=false
 
 The ClusteringUserObject interacts with the auxiliary system of the simulation. It iterates over 
-the mesh elements and compares them using a specified variable, `metric_var`, which must belong to 
-the AuxVariables System. This enables the use of values computed by indicators. 
+the mesh elements and compares them using a specified variable, `metric_var`, which must belong to
+the `AuxVariables` System. This enables the use of values computed by indicators.
 
 Currently, the element type must be `CONSTANT MONOMIAL`, since no quadrature point integration is performed
 when retrieving values from the auxiliary system. If two elements are determined to

--- a/doc/content/source/userobjects/ClusteringUserObject.md
+++ b/doc/content/source/userobjects/ClusteringUserObject.md
@@ -3,13 +3,17 @@
 ## Description
 
 ClusteringUserObject works as the base class for clustering in Cardinal for indentifying clusters, where it could be beneficial to apply
-mesh-tally amalgamation both in post processing or on the fly. ClusteringUserObject class has been created, inheriting from 
-[GeneralUserObject](https://mooseframework.inl.gov/docs/doxygen/moose/classGeneralUserObject.html).
-The ClusteringUserObject interacts with the _auxiliary_system of the simulation. It iterates over 
+mesh-tally amalgamation both in post processing or on the fly. ClusteringUserObject inherits from 
+[GeneralUserObject](GeneralUserObject.md). It implements the mesh walking process. This base class assumes that only active
+elements, sharing at least one common side can be clustered together based on some heuristics. 
+
+!listing /ClusteringUserObject.h start=doco-user-object-interface-begin end=doco-user-object-interface-end include-start=false
+
+The ClusteringUserObject interacts with the auxiliary system of the simulation. It iterates over 
 the mesh elements and compares them using a specified variable, `metric_var`, which must belong to 
-the [AuxVariables System](https://cardinal.cels.anl.gov/syntax/AuxVariables/index.html). This enables the use of values
-computed by indicators. Currently, the element 
-type must be CONSTANT MONOMIAL, since no quadrature point integration is performed
+the AuxVariables System. This enables the use of values computed by indicators. 
+
+Currently, the element type must be `CONSTANT MONOMIAL`, since no quadrature point integration is performed
 when retrieving values from the auxiliary system. If two elements are determined to
 belong to the same cluster, their extra element integer IDs are unified by setting them
 to the element_id of the first element in that cluster. Any UserObject derived from ClusteringUserObject 

--- a/doc/content/source/userobjects/ClusteringUserObject.md
+++ b/doc/content/source/userobjects/ClusteringUserObject.md
@@ -1,0 +1,17 @@
+# ClusteringUserObject
+
+## Description
+
+ClusteringUserObject works as the base class for clustering in Cardinal for indentifying clusters, where it could be beneficial to apply
+mesh-tally amalgamation both in post processing or on the fly. ClusteringUserObject class has been created, inheriting from 
+[GeneralUserObject](https://mooseframework.inl.gov/docs/doxygen/moose/classGeneralUserObject.html).
+The ClusteringUserObject interacts with the _auxiliary_system of the simulation. It iterates over 
+the mesh elements and compares them using a specified variable, `metric_var`, which must belong to 
+the [AuxVariables System](https://cardinal.cels.anl.gov/syntax/AuxVariables/index.html). This enables the use of values
+computed by indicators. Currently, the element 
+type must be CONSTANT MONOMIAL, since no quadrature point integration is performed
+when retrieving values from the auxiliary system. If two elements are determined to
+belong to the same cluster, their extra element integer IDs are unified by setting them
+to the element_id of the first element in that cluster. Any UserObject derived from ClusteringUserObject 
+must override the `belongsToCluster()` method, where the specific clustering heuristic / logic is implemented.
+

--- a/doc/content/source/userobjects/ClusteringUserObject.md
+++ b/doc/content/source/userobjects/ClusteringUserObject.md
@@ -2,21 +2,17 @@
 
 ## Description
 
-`ClusteringUserObject` works as the base class in Cardinal for indentifying clusters in mesh results, where it may be beneficial to apply
-mesh-tally amalgamation both in post processing or on the fly. ClusteringUserObject inherits from 
-[GeneralUserObject](GeneralUserObject.md). It implements the mesh walking process. This base class assumes that only active
+`ClusteringUserObject` works as the base class in Cardinal for identifying clusters in mesh results, where it may be beneficial to apply
+mesh-tally amalgamation both in post processing or on the fly. It implements the mesh walking process. This base class assumes that only active
 elements, sharing at least one common side can be clustered together based on heuristics that will be implemented 
 in user objects derived from this class. 
 
-!listing /ClusteringUserObject.h start=doco-user-object-interface-begin end=doco-user-object-interface-end include-start=false
+The `ClusteringUserObject` interacts with the AuxiliarySystem of the simulation. It iterates over 
+the mesh elements and compares their metric variable value using different heuristics.
 
-The ClusteringUserObject interacts with the auxiliary system of the simulation. It iterates over 
-the mesh elements and compares them using a specified variable, `metric_var`, which must belong to
-the `AuxVariables` System. This enables the use of values computed by indicators.
-
-Currently, the element type must be `CONSTANT MONOMIAL`, since no quadrature point integration is performed
+Currently, the variable type must be `CONSTANT MONOMIAL`, since no quadrature point integration is performed
 when retrieving values from the auxiliary system. If two elements are determined to
 belong to the same cluster, their extra element integer IDs are unified by setting them
-to the element_id of the first element in that cluster. Any UserObject derived from ClusteringUserObject 
+to the element_id of the first element in that cluster. Any UserObject derived from `ClusteringUserObject` 
 must override the `belongsToCluster()` method, where the specific clustering heuristic / logic is implemented.
 

--- a/doc/content/source/userobjects/ClusteringUserObject.md
+++ b/doc/content/source/userobjects/ClusteringUserObject.md
@@ -3,16 +3,11 @@
 ## Description
 
 `ClusteringUserObject` works as the base class in Cardinal for identifying clusters in mesh results, where it may be beneficial to apply
-mesh-tally amalgamation both in post processing or on the fly. It implements the mesh walking process. This base class assumes that only active
-elements, sharing at least one common side can be clustered together based on heuristics that will be implemented 
-in user objects derived from this class. 
+mesh-tally amalgamation both in post processing or on the fly. It hosts the functionality to implement any clustering heuristics.
 
-The `ClusteringUserObject` interacts with the [`AuxiliarySystem`] (AuxKernels/index.md) of the simulation. It iterates over 
-the mesh elements and compares their metric variable value using different heuristics.
+The `ClusteringUserObject` interacts with the [`AuxiliarySystem`] (AuxKernels/index.md) of the simulation.
 
 Currently, the variable type must be `CONSTANT MONOMIAL`, since no quadrature point integration is performed
-when retrieving values from the auxiliary system. If two elements are determined to
-belong to the same cluster, their extra element integer IDs are unified by setting them
-to the element_id of the first element in that cluster. Any `UserObject` derived from `ClusteringUserObject` 
+when retrieving values from the auxiliary system. Any `UserObject` derived from `ClusteringUserObject` 
 must override the `belongsToCluster()` method, where the specific clustering heuristic / logic is implemented.
 

--- a/doc/content/source/userobjects/ClusteringUserObject.md
+++ b/doc/content/source/userobjects/ClusteringUserObject.md
@@ -7,12 +7,12 @@ mesh-tally amalgamation both in post processing or on the fly. It implements the
 elements, sharing at least one common side can be clustered together based on heuristics that will be implemented 
 in user objects derived from this class. 
 
-The `ClusteringUserObject` interacts with the AuxiliarySystem of the simulation. It iterates over 
+The `ClusteringUserObject` interacts with the [`AuxiliarySystem`] (AuxKernels/index.md) of the simulation. It iterates over 
 the mesh elements and compares their metric variable value using different heuristics.
 
 Currently, the variable type must be `CONSTANT MONOMIAL`, since no quadrature point integration is performed
 when retrieving values from the auxiliary system. If two elements are determined to
 belong to the same cluster, their extra element integer IDs are unified by setting them
-to the element_id of the first element in that cluster. Any UserObject derived from `ClusteringUserObject` 
+to the element_id of the first element in that cluster. Any `UserObject` derived from `ClusteringUserObject` 
 must override the `belongsToCluster()` method, where the specific clustering heuristic / logic is implemented.
 

--- a/include/userobjects/ClusteringUserObject.h
+++ b/include/userobjects/ClusteringUserObject.h
@@ -21,7 +21,7 @@ protected:
   Real getMetricData(const libMesh::Elem * elem) const;
 
   /**
-   * A purely virtual fucntion which must be overrided in derived classes.
+   * A purely virtual function which must be overrided in derived classes.
    * It applies the clustering logic for two elements in the derived class
    */
   virtual bool belongsToCluster(libMesh::Elem * base_element, libMesh::Elem * neighbor_elem) const = 0;

--- a/include/userobjects/ClusteringUserObject.h
+++ b/include/userobjects/ClusteringUserObject.h
@@ -1,9 +1,31 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
 #pragma once
 
 #include "GeneralUserObject.h"
 
+//forward declaration of the AuxiliarySystem
 class AuxiliarySystem;
 
+/*
+ * Base class for clustering in cardinal.
+ * */
 class ClusteringUserObject : public GeneralUserObject
 {
 
@@ -14,21 +36,52 @@ public:
   virtual void execute() override;
   virtual void initialize() override {};
   virtual void finalize() override {};
-  int getExtraIntegerScore(libMesh::Elem * elem);
+
+  ///Getter function for the extra element integer value of an element
+  int getExtraIntegerScore(libMesh::Elem * elem) const;
 
 protected:
+
+  ///Sets the extra element integer id of every active element in the mesh to NOT_VISITED
   void applyNoClusteringInitialCondition();
+
+  ///Cluster finder method. It iterates thourgh the elements in the mesh.
+  ///if two elements belongs to a cluster it changes the extra element integer of those two elements to a similar value.
   void findCluster();
-  Real getMetricData(const libMesh::Elem * elem);
+
+  ///Get the metric data from the auxiliary system for an element.
+  Real getMetricData(const libMesh::Elem * elem) const;
+
+  ///A purely virtual fucntion which must be overrided in derived classes.
+  ///It applies the clustering logic for two elements in the derived class
   virtual bool belongsToCluster(libMesh::Elem * base_element, libMesh::Elem * neighbor_elem) = 0;
 
+  ///Holds the ExtraElementIDName
   const ExtraElementIDName _id_name;
+
+  ///Mesh reference
   libMesh::MeshBase & _mesh;
+
+  ///Name of the metric variable based on which clustering is done
   const AuxVariableName _metric_variable_name;
+
+  ///Metric variable
   MooseVariableBase & _metric_variable;
+
+  ///AuxiliarySystem reference
   AuxiliarySystem & _auxiliary_system;
+
+  ///DOF map
   libMesh::DofMap & _dof_map;
+
+  ///Metric variable index
   unsigned int _metric_variable_index;
+
+  ///Extra element id index
   unsigned int _extra_integer_index = 0;
-  static const int not_visited = -1;
+
+  ///If extra element integer value is equal to NOT_VISITED  that indicates
+  ///an element has not yet been visited or assigned to a cluster while findCluster
+  ///method is iterating through the elements in the mesh.
+  static constexpr int NOT_VISITED = -1;
 };

--- a/include/userobjects/ClusteringUserObject.h
+++ b/include/userobjects/ClusteringUserObject.h
@@ -4,9 +4,7 @@
 
 class AuxiliarySystem;
 
-/*
- * Base class for clustering in cardinal.
- * */
+/* Base class for clustering in cardinal. */
 class ClusteringUserObject : public GeneralUserObject
 {
 
@@ -14,24 +12,11 @@ public:
   static InputParameters validParams();
   ClusteringUserObject(const InputParameters & parameters);
 
-  virtual void execute() override;
+  virtual void execute() override {};
   virtual void initialize() override {};
   virtual void finalize() override {};
 
-  ///Getter function for the extra element integer value of an element
-  int getExtraIntegerScore(libMesh::Elem * elem) const;
-
 protected:
-
-  ///Sets the extra element integer id of every active element in the mesh to NOT_VISITED
-  void applyNoClusteringInitialCondition();
-
-  /**
-   * Cluster finder method. It iterates thourgh the elements in the mesh.
-   * if two elements belongs to a cluster it changes the extra element integer of those two elements to a similar value.
-   */
-  void findCluster();
-
   ///Get the metric data from the auxiliary system for an element.
   Real getMetricData(const libMesh::Elem * elem) const;
 
@@ -39,10 +24,7 @@ protected:
    * A purely virtual fucntion which must be overrided in derived classes.
    * It applies the clustering logic for two elements in the derived class
    */
-  virtual bool belongsToCluster(libMesh::Elem * base_element, libMesh::Elem * neighbor_elem) = 0;
-
-  ///Holds the ExtraElementIDName
-  const ExtraElementIDName _id_name;
+  virtual bool belongsToCluster(libMesh::Elem * base_element, libMesh::Elem * neighbor_elem) const = 0;
 
   ///Mesh reference
   libMesh::MeshBase & _mesh;
@@ -61,14 +43,4 @@ protected:
 
   ///Metric variable index
   unsigned int _metric_variable_index;
-
-  ///Extra element id index
-  unsigned int _extra_integer_index = 0;
-
-  /**
-   * If extra element integer value is equal to NOT_VISITED  that indicates
-   * an element has not yet been visited or assigned to a cluster while findCluster
-   * method is iterating through the elements in the mesh.
-   */
-  static constexpr int NOT_VISITED = -1;
 };

--- a/include/userobjects/ClusteringUserObject.h
+++ b/include/userobjects/ClusteringUserObject.h
@@ -2,7 +2,6 @@
 
 #include "GeneralUserObject.h"
 
-//forward declaration of the AuxiliarySystem
 class AuxiliarySystem;
 
 /*
@@ -27,15 +26,19 @@ protected:
   ///Sets the extra element integer id of every active element in the mesh to NOT_VISITED
   void applyNoClusteringInitialCondition();
 
-  ///Cluster finder method. It iterates thourgh the elements in the mesh.
-  ///if two elements belongs to a cluster it changes the extra element integer of those two elements to a similar value.
+  /**
+   * Cluster finder method. It iterates thourgh the elements in the mesh.
+   * if two elements belongs to a cluster it changes the extra element integer of those two elements to a similar value.
+   */
   void findCluster();
 
   ///Get the metric data from the auxiliary system for an element.
   Real getMetricData(const libMesh::Elem * elem) const;
 
-  ///A purely virtual fucntion which must be overrided in derived classes.
-  ///It applies the clustering logic for two elements in the derived class
+  /**
+   * A purely virtual fucntion which must be overrided in derived classes.
+   * It applies the clustering logic for two elements in the derived class
+   */
   virtual bool belongsToCluster(libMesh::Elem * base_element, libMesh::Elem * neighbor_elem) = 0;
 
   ///Holds the ExtraElementIDName
@@ -62,8 +65,10 @@ protected:
   ///Extra element id index
   unsigned int _extra_integer_index = 0;
 
-  ///If extra element integer value is equal to NOT_VISITED  that indicates
-  ///an element has not yet been visited or assigned to a cluster while findCluster
-  ///method is iterating through the elements in the mesh.
+  /**
+   * If extra element integer value is equal to NOT_VISITED  that indicates
+   * an element has not yet been visited or assigned to a cluster while findCluster
+   * method is iterating through the elements in the mesh.
+   */
   static constexpr int NOT_VISITED = -1;
 };

--- a/include/userobjects/ClusteringUserObject.h
+++ b/include/userobjects/ClusteringUserObject.h
@@ -1,21 +1,3 @@
-/********************************************************************/
-/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
-/*                             Cardinal                             */
-/*                                                                  */
-/*                  (c) 2021 UChicago Argonne, LLC                  */
-/*                        ALL RIGHTS RESERVED                       */
-/*                                                                  */
-/*                 Prepared by UChicago Argonne, LLC                */
-/*               Under Contract No. DE-AC02-06CH11357               */
-/*                With the U. S. Department of Energy               */
-/*                                                                  */
-/*             Prepared by Battelle Energy Alliance, LLC            */
-/*               Under Contract No. DE-AC07-05ID14517               */
-/*                With the U. S. Department of Energy               */
-/*                                                                  */
-/*                 See LICENSE for full restrictions                */
-/********************************************************************/
-
 #pragma once
 
 #include "GeneralUserObject.h"

--- a/include/userobjects/ClusteringUserObject.h
+++ b/include/userobjects/ClusteringUserObject.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "GeneralUserObject.h"
+
+class AuxiliarySystem;
+
+class ClusteringUserObject : public GeneralUserObject
+{
+
+public:
+  static InputParameters validParams();
+  ClusteringUserObject(const InputParameters & parameters);
+
+  virtual void execute() override;
+  virtual void initialize() override {};
+  virtual void finalize() override {};
+  int getExtraIntegerScore(libMesh::Elem * elem);
+
+protected:
+  void applyNoClusteringInitialCondition();
+  void findCluster();
+  Real getMetricData(const libMesh::Elem * elem);
+  virtual bool belongsToCluster(libMesh::Elem * base_element, libMesh::Elem * neighbor_elem) = 0;
+
+  const ExtraElementIDName _id_name;
+  libMesh::MeshBase & _mesh;
+  const AuxVariableName _metric_variable_name;
+  MooseVariableBase & _metric_variable;
+  AuxiliarySystem & _auxiliary_system;
+  libMesh::DofMap & _dof_map;
+  unsigned int _metric_variable_index;
+  unsigned int _extra_integer_index = 0;
+  static const int not_visited = -1;
+};

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -5,7 +5,6 @@ InputParameters
 ClusteringUserObject::validParams()
 {
   InputParameters params = GeneralUserObject::validParams();
-  params.addRequiredParam<ExtraElementIDName>("id_name", "extra_element_integer_id name");
   params.addRequiredParam<AuxVariableName>(
       "metric_variable_name", "The name of the variable based on which clustering will be done");
 
@@ -14,7 +13,6 @@ ClusteringUserObject::validParams()
 
 ClusteringUserObject::ClusteringUserObject(const InputParameters & parameters)
   : GeneralUserObject(parameters),
-    _id_name(getParam<ExtraElementIDName>("id_name")),
     _mesh(_fe_problem.mesh().getMesh()),
     _metric_variable_name(getParam<AuxVariableName>("metric_variable_name")),
     _metric_variable(_fe_problem.getVariable(_tid, _metric_variable_name)),
@@ -22,29 +20,11 @@ ClusteringUserObject::ClusteringUserObject(const InputParameters & parameters)
     _dof_map(_auxiliary_system.dofMap()),
     _metric_variable_index(_auxiliary_system.getVariable(_tid, _metric_variable_name).number())
 {
-  if (!_mesh.has_elem_integer(_id_name))
-  {
-    mooseWarning("Mesh does not have an extra element integer named ",
-                 _id_name,
-                 "."
-                 " so adding the ",
-                 _id_name,
-                 " generator defines it with extra_element_integers.");
-    _mesh.add_elem_integer(_id_name);
-  }
   //check if the element type if CONSTANT MONOMIAL. If not then throw a mooseError.
   if (_metric_variable.feType()!=FEType(CONSTANT, MONOMIAL))
     mooseError("Variable must be type of CONSTANT MONOMIAL");
-  _extra_integer_index = _mesh.get_elem_integer_index(_id_name);
 }
 
-void
-ClusteringUserObject::execute()
-{
-  //set the extra element integer value to NOT_VISITED
-  applyNoClusteringInitialCondition();
-  findCluster();
-}
 
 Real
 ClusteringUserObject::getMetricData(const libMesh::Elem * elem) const
@@ -56,63 +36,4 @@ ClusteringUserObject::getMetricData(const libMesh::Elem * elem) const
   _auxiliary_system.solution().get(dof_indices, solution_value);
 
   return solution_value[0];
-}
-
-void
-ClusteringUserObject::applyNoClusteringInitialCondition()
-{
-  for (auto & elem : _mesh.active_element_ptr_range())
-    elem->set_extra_integer(_extra_integer_index, NOT_VISITED);
-}
-
-void
-ClusteringUserObject::findCluster()
-{
-
-  std::stack<libMesh::Elem *> neighbor_stack;
-
-  for (auto & elem : _mesh.active_element_ptr_range())
-  {
-    //if elem->get_extra_integer(_extra_integer_index) != NOT_VISITED that means we have already touched that element.
-    // No need to visit it again.
-    if (elem->get_extra_integer(_extra_integer_index) != NOT_VISITED)
-      continue;
-
-    int cluster_id = elem->id();
-    neighbor_stack.push(elem);
-
-    while (!neighbor_stack.empty())
-    {
-      libMesh::Elem * current_elem = neighbor_stack.top();
-      neighbor_stack.pop();
-
-      //Iterating through the side as, two elements to be clustered together they must share one side or face.
-      for (unsigned int s = 0; s < current_elem->n_sides(); s++)
-      {
-        libMesh::Elem * neighbor_elem = current_elem->neighbor_ptr(s);
-        //check if the neighbor_elem is
-        //1. not a null ptr
-        //2. an active element
-        //3. NOT_VISITED before
-        if (neighbor_elem && neighbor_elem->active() &&
-            neighbor_elem->get_extra_integer(_extra_integer_index) == NOT_VISITED)
-        {
-          if (belongsToCluster(current_elem, neighbor_elem))
-          {
-            //if elements belong to a cluster then change the extra element integer
-            //of both elements to the element id of the current element
-            elem->set_extra_integer(_extra_integer_index, cluster_id);
-            neighbor_elem->set_extra_integer(_extra_integer_index, cluster_id);
-            neighbor_stack.push(neighbor_elem);
-          }
-        }
-      }
-    }
-  }
-}
-
-int
-ClusteringUserObject::getExtraIntegerScore(libMesh::Elem * elem) const
-{
-  return elem->get_extra_integer(_extra_integer_index);
 }

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -1,21 +1,3 @@
-/********************************************************************/
-/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
-/*                             Cardinal                             */
-/*                                                                  */
-/*                  (c) 2021 UChicago Argonne, LLC                  */
-/*                        ALL RIGHTS RESERVED                       */
-/*                                                                  */
-/*                 Prepared by UChicago Argonne, LLC                */
-/*               Under Contract No. DE-AC02-06CH11357               */
-/*                With the U. S. Department of Energy               */
-/*                                                                  */
-/*             Prepared by Battelle Energy Alliance, LLC            */
-/*               Under Contract No. DE-AC07-05ID14517               */
-/*                With the U. S. Department of Energy               */
-/*                                                                  */
-/*                 See LICENSE for full restrictions                */
-/********************************************************************/
-
 #include "ClusteringUserObject.h"
 #include "AuxiliarySystem.h"
 

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -80,7 +80,7 @@ void
 ClusteringUserObject::applyNoClusteringInitialCondition()
 {
   for (auto & elem : _mesh.active_element_ptr_range())
-    elem->set_extra_integer(_extra_integer_index, not_visited);
+    elem->set_extra_integer(_extra_integer_index, NOT_VISITED);
 }
 
 void

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -104,7 +104,7 @@ ClusteringUserObject::findCluster()
       libMesh::Elem * current_elem = neighbor_stack.top();
       neighbor_stack.pop();
 
-      //Iterating through the side as, two elements to be clusted together they must share one side or face.
+      //Iterating through the side as, two elements to be clustered together they must share one side or face.
       for (unsigned int s = 0; s < current_elem->n_sides(); s++)
       {
         libMesh::Elem * neighbor_elem = current_elem->neighbor_ptr(s);

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -1,3 +1,21 @@
+/********************************************************************/
+/*                  SOFTWARE COPYRIGHT NOTIFICATION                 */
+/*                             Cardinal                             */
+/*                                                                  */
+/*                  (c) 2021 UChicago Argonne, LLC                  */
+/*                        ALL RIGHTS RESERVED                       */
+/*                                                                  */
+/*                 Prepared by UChicago Argonne, LLC                */
+/*               Under Contract No. DE-AC02-06CH11357               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*             Prepared by Battelle Energy Alliance, LLC            */
+/*               Under Contract No. DE-AC07-05ID14517               */
+/*                With the U. S. Department of Energy               */
+/*                                                                  */
+/*                 See LICENSE for full restrictions                */
+/********************************************************************/
+
 #include "ClusteringUserObject.h"
 #include "AuxiliarySystem.h"
 
@@ -8,7 +26,6 @@ ClusteringUserObject::validParams()
   params.addRequiredParam<ExtraElementIDName>("id_name", "extra_element_integer_id name");
   params.addRequiredParam<AuxVariableName>(
       "metric_variable_name", "The name of the variable based on which clustering will be done");
-  params.addClassDescription("Base clustering object that for other heuristic based user obejct. ");
 
   return params;
 }
@@ -33,6 +50,7 @@ ClusteringUserObject::ClusteringUserObject(const InputParameters & parameters)
                  " generator defines it with extra_element_integers.");
     _mesh.add_elem_integer(_id_name);
   }
+  //check if the element type if CONSTANT MONOMIAL. If not then throw a mooseError.
   if (_metric_variable.feType()!=FEType(CONSTANT, MONOMIAL))
     mooseError("Variable must be type of CONSTANT MONOMIAL");
   _extra_integer_index = _mesh.get_elem_integer_index(_id_name);
@@ -41,12 +59,13 @@ ClusteringUserObject::ClusteringUserObject(const InputParameters & parameters)
 void
 ClusteringUserObject::execute()
 {
+  //set the extra element integer value to NOT_VISITED
   applyNoClusteringInitialCondition();
   findCluster();
 }
 
 Real
-ClusteringUserObject::getMetricData(const libMesh::Elem * elem)
+ClusteringUserObject::getMetricData(const libMesh::Elem * elem) const
 {
 
   std::vector<libMesh::dof_id_type> dof_indices;
@@ -54,16 +73,14 @@ ClusteringUserObject::getMetricData(const libMesh::Elem * elem)
   _dof_map.dof_indices(elem, dof_indices, _metric_variable_index);
   _auxiliary_system.solution().get(dof_indices, solution_value);
 
-  return static_cast<Real>(solution_value[0]);
+  return solution_value[0];
 }
 
 void
 ClusteringUserObject::applyNoClusteringInitialCondition()
 {
   for (auto & elem : _mesh.active_element_ptr_range())
-  {
     elem->set_extra_integer(_extra_integer_index, not_visited);
-  }
 }
 
 void
@@ -74,10 +91,11 @@ ClusteringUserObject::findCluster()
 
   for (auto & elem : _mesh.active_element_ptr_range())
   {
-    if (elem->get_extra_integer(_extra_integer_index) != not_visited)
-    {
+    if (elem->get_extra_integer(_extra_integer_index) != NOT_VISITED)
+      //if elem->get_extra_integer(_extra_integer_index) != NOT_VISITED that means we have
+      //already touched that element. No need to visit it again.
       continue;
-    }
+
     int cluster_id = elem->id();
     neighbor_stack.push(elem);
 
@@ -86,16 +104,21 @@ ClusteringUserObject::findCluster()
       libMesh::Elem * current_elem = neighbor_stack.top();
       neighbor_stack.pop();
 
+      //Iterating through the side as, two elements to be clusted together they must share one side or face.
       for (unsigned int s = 0; s < current_elem->n_sides(); s++)
       {
         libMesh::Elem * neighbor_elem = current_elem->neighbor_ptr(s);
-
+        //check if the neighbor_elem is
+        //1. not a null ptr
+        //2. an active element
+        //3. NOT_VISITED before
         if (neighbor_elem && neighbor_elem->active() &&
-            neighbor_elem->get_extra_integer(_extra_integer_index) == not_visited)
+            neighbor_elem->get_extra_integer(_extra_integer_index) == NOT_VISITED)
         {
           if (belongsToCluster(current_elem, neighbor_elem))
           {
-
+            //if elements belong to a cluster then change the extra element integer
+            //of both elements to the element id of the current element
             elem->set_extra_integer(_extra_integer_index, cluster_id);
             neighbor_elem->set_extra_integer(_extra_integer_index, cluster_id);
             neighbor_stack.push(neighbor_elem);
@@ -107,7 +130,7 @@ ClusteringUserObject::findCluster()
 }
 
 int
-ClusteringUserObject::getExtraIntegerScore(libMesh::Elem * elem)
+ClusteringUserObject::getExtraIntegerScore(libMesh::Elem * elem) const
 {
   return elem->get_extra_integer(_extra_integer_index);
 }

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -73,9 +73,9 @@ ClusteringUserObject::findCluster()
 
   for (auto & elem : _mesh.active_element_ptr_range())
   {
+    //if elem->get_extra_integer(_extra_integer_index) != NOT_VISITED that means we have already touched that element.
+    // No need to visit it again.
     if (elem->get_extra_integer(_extra_integer_index) != NOT_VISITED)
-      //if elem->get_extra_integer(_extra_integer_index) != NOT_VISITED that means we have
-      //already touched that element. No need to visit it again.
       continue;
 
     int cluster_id = elem->id();

--- a/src/userobjects/ClusteringUserObject.C
+++ b/src/userobjects/ClusteringUserObject.C
@@ -1,0 +1,113 @@
+#include "ClusteringUserObject.h"
+#include "AuxiliarySystem.h"
+
+InputParameters
+ClusteringUserObject::validParams()
+{
+  InputParameters params = GeneralUserObject::validParams();
+  params.addRequiredParam<ExtraElementIDName>("id_name", "extra_element_integer_id name");
+  params.addRequiredParam<AuxVariableName>(
+      "metric_variable_name", "The name of the variable based on which clustering will be done");
+  params.addClassDescription("Base clustering object that for other heuristic based user obejct. ");
+
+  return params;
+}
+
+ClusteringUserObject::ClusteringUserObject(const InputParameters & parameters)
+  : GeneralUserObject(parameters),
+    _id_name(getParam<ExtraElementIDName>("id_name")),
+    _mesh(_fe_problem.mesh().getMesh()),
+    _metric_variable_name(getParam<AuxVariableName>("metric_variable_name")),
+    _metric_variable(_fe_problem.getVariable(_tid, _metric_variable_name)),
+    _auxiliary_system(_fe_problem.getAuxiliarySystem()),
+    _dof_map(_auxiliary_system.dofMap()),
+    _metric_variable_index(_auxiliary_system.getVariable(_tid, _metric_variable_name).number())
+{
+  if (!_mesh.has_elem_integer(_id_name))
+  {
+    mooseWarning("Mesh does not have an extra element integer named ",
+                 _id_name,
+                 "."
+                 " so adding the ",
+                 _id_name,
+                 " generator defines it with extra_element_integers.");
+    _mesh.add_elem_integer(_id_name);
+  }
+  if (_metric_variable.feType()!=FEType(CONSTANT, MONOMIAL))
+    mooseError("Variable must be type of CONSTANT MONOMIAL");
+  _extra_integer_index = _mesh.get_elem_integer_index(_id_name);
+}
+
+void
+ClusteringUserObject::execute()
+{
+  applyNoClusteringInitialCondition();
+  findCluster();
+}
+
+Real
+ClusteringUserObject::getMetricData(const libMesh::Elem * elem)
+{
+
+  std::vector<libMesh::dof_id_type> dof_indices;
+  std::vector<double> solution_value(1);
+  _dof_map.dof_indices(elem, dof_indices, _metric_variable_index);
+  _auxiliary_system.solution().get(dof_indices, solution_value);
+
+  return static_cast<Real>(solution_value[0]);
+}
+
+void
+ClusteringUserObject::applyNoClusteringInitialCondition()
+{
+  for (auto & elem : _mesh.active_element_ptr_range())
+  {
+    elem->set_extra_integer(_extra_integer_index, not_visited);
+  }
+}
+
+void
+ClusteringUserObject::findCluster()
+{
+
+  std::stack<libMesh::Elem *> neighbor_stack;
+
+  for (auto & elem : _mesh.active_element_ptr_range())
+  {
+    if (elem->get_extra_integer(_extra_integer_index) != not_visited)
+    {
+      continue;
+    }
+    int cluster_id = elem->id();
+    neighbor_stack.push(elem);
+
+    while (!neighbor_stack.empty())
+    {
+      libMesh::Elem * current_elem = neighbor_stack.top();
+      neighbor_stack.pop();
+
+      for (unsigned int s = 0; s < current_elem->n_sides(); s++)
+      {
+        libMesh::Elem * neighbor_elem = current_elem->neighbor_ptr(s);
+
+        if (neighbor_elem && neighbor_elem->active() &&
+            neighbor_elem->get_extra_integer(_extra_integer_index) == not_visited)
+        {
+          if (belongsToCluster(current_elem, neighbor_elem))
+          {
+
+            elem->set_extra_integer(_extra_integer_index, cluster_id);
+            neighbor_elem->set_extra_integer(_extra_integer_index, cluster_id);
+            neighbor_stack.push(neighbor_elem);
+          }
+        }
+      }
+    }
+  }
+}
+
+int
+ClusteringUserObject::getExtraIntegerScore(libMesh::Elem * elem)
+{
+  return elem->get_extra_integer(_extra_integer_index);
+}


### PR DESCRIPTION
This PR introduces the foundation for clustering in Cardinal along with some clustering heuristic user objects.
The base class: `ClusteringUserObject `class has been created, inheriting from `GeneralUserObject`, and serves as the base class for implementing various clustering heuristics. The `ClusteringUserObject` interacts with the _auxiliary_system of the simulation. It iterates over the mesh elements and compares them using a specified variable, metric_var, which must belong to the _auxiliary_system. This enables the use of values computed by indicators. Currently, the element type must be CONSTANT MONOMIAL, since no quadrature point integration is performed when retrieving values from the auxiliary system. If two elements are determined to belong to the same cluster, their extra element integer IDs are unified by setting them to the element_id of the first element in that cluster. Any UserObject derived from `ClusteringUserObject` must override the `belongsToCluster() `method, where the specific clustering logic is implemented. 

Derived Classes: 

- `BooleanComboHeuristicUserObject`: Combines multiple clustering heuristics using Boolean logic (e.g., AND, OR) to impose overlapping clusters.
- `ValueFractionHeuristicUserObject`:Clusters a specified fraction of elements with extreme metric values (either highest or lowest).
- `ThresholdHeuristicsUserObject`: Clusters elements when both have metric values above a given threshold (or optionally lower).
- `ValueDifferenceHeuristicUserObject`: Clusters elements if the relative difference between their metric values is below a specified tolerance.
- `ValueRangeHeuristicUserObject`: Clusters elements if both of their metric values fall within a specified range.

closes #2 
